### PR TITLE
Fix README.md bad URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ someone else how they have voted.
 ## Introduction
 
 For an introduction to one possible application of our SDK, please refer to
-[the high-level narrative description](Informal/description/election.html).
+[the high-level narrative description](Informal/description/election.rst).
 
 The high-level description is one of many potential applications of
 ElectionGuard. Some of the specifics could be replaced with


### PR DESCRIPTION
Updated from [issue 3](https://github.com/microsoft/ElectionGuard-SDK-Specification/issues/3). Link URL pointed to html rather than rst file. 