### PR TITLE
Date and time compliant with RFC3339

### DIFF
--- a/Formal/schema/schemas/ballot_coding.schema.json
+++ b/Formal/schema/schemas/ballot_coding.schema.json
@@ -246,7 +246,8 @@
       "$ref": "#/definitions/County"
     },
     "date": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "districts": {
       "items": {

--- a/Formal/schema/schemas/ballot_info.schema.json
+++ b/Formal/schema/schemas/ballot_info.schema.json
@@ -11,11 +11,13 @@
     },
     "date": {
       "description": "The date the ballot was encrypted.",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "time": {
       "description": "The time the ballot was encrypted.",
-      "type": "string"
+      "type": "string",
+      "format": "time"
     },
     "tracker": {
       "description": "The tracker code generated for this ballot.",

--- a/Formal/schema/schemas/election_parameters.schema.json
+++ b/Formal/schema/schemas/election_parameters.schema.json
@@ -7,7 +7,8 @@
   "properties": {
     "date": {
       "description": "The date on which the election takes place.",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "location": {
       "description": "The location where the election takes place",


### PR DESCRIPTION
The format for the 'time' and 'date' fields is not specified in the validation, according to RFC3339.

